### PR TITLE
Add option to use session best instead of PB splits

### DIFF
--- a/src/AdvSettings.as
+++ b/src/AdvSettings.as
@@ -12,6 +12,28 @@ namespace AdvSettings{
             mapSpeeds.ClearPB();
             UI::ShowNotification("Cleared pb speeds for all maps", 5000);
         }
+
+        UI::Separator();
+
+        if (mapSpeeds is null) {
+            UI::TextWrapped("No map speeds loaded.");
+            return;
+        }
+
+        UI::TextWrapped("Map UID: " + mapSpeeds.mapId);
+        DrawSpeedRecDebug("currentSpeeds", mapSpeeds.currentSpeeds);
+        DrawSpeedRecDebug("sessionBest", mapSpeeds.sessionBest);
+        DrawSpeedRecDebug("bestSpeeds", mapSpeeds.bestSpeeds);
+    }
+
+    void DrawSpeedRecDebug(const string &in name, SpeedRecording@ sr) {
+        UI::Text(name + ": ");
+        UI::SameLine();
+        if (sr !is null) {
+            sr.DrawDebugInfo();
+        } else {
+            UI::Text("null");
+        }
     }
 
     void DeleteFiles(){

--- a/src/Settings.as
+++ b/src/Settings.as
@@ -1,4 +1,4 @@
-[Setting name="Synchronize split speeds with session PB" category="General" description="Delete stored speed splits when the session time splits are also gone. With this disabled the speed splits are stored permanently."]
+[Setting name="Synchronize split speeds with PB" category="General" description="Delete stored speed splits when they do not match your PB time. With this disabled the speed splits are stored permanently."]
 bool keepSync = true;
 
 [Setting name="Compare to Session Best (not PB)" category="General" description="Compare your speed splits to the best splits from the current session instead of PB speed splits. Resets when a new map loads."]

--- a/src/Settings.as
+++ b/src/Settings.as
@@ -1,6 +1,9 @@
 [Setting name="Synchronize split speeds with session PB" category="General" description="Delete stored speed splits when the session time splits are also gone. With this disabled the speed splits are stored permanently."]
 bool keepSync = true;
 
+[Setting name="Compare to Session Best (not PB)" category="General" description="Compare your speed splits to the best splits from the current session instead of PB speed splits. Resets when a new map loads."]
+bool useSessionBestNotPB = false;
+
 [Setting name="Show current speed at cp" category="UI"]
 bool showCurrentSpeed = true;
 

--- a/src/SpeedRecording.as
+++ b/src/SpeedRecording.as
@@ -22,7 +22,6 @@ class SpeedRecording {
 
     void DrawDebugInfo() {
         string[] cpsStr = {};
-        if (cps is null) @cps = {};
         for (uint i = 0; i < cps.Length; i++) {
             cpsStr.InsertLast(tostring(cps[i]));
         }

--- a/src/SpeedRecording.as
+++ b/src/SpeedRecording.as
@@ -19,6 +19,15 @@ class SpeedRecording {
 
         Json::ToFile(path, speeds);
     }
+
+    void DrawDebugInfo() {
+        string[] cpsStr = {};
+        if (cps is null) @cps = {};
+        for (uint i = 0; i < cps.Length; i++) {
+            cpsStr.InsertLast(tostring(cps[i]));
+        }
+        UI::TextWrapped("SpeedRecording < time = " + Time::Format(time) + ", cps = { " + (string::Join(cpsStr, " / ")) + " } >");
+    }
 };
 
 namespace SpeedRecording {


### PR DESCRIPTION
Simple implementation of session best comparison instead of PB. 

To avoid confusion, I've changed the 'Synchronize split speeds with PB' setting's name (removed 'session') and description (the previous wording was confusing, this is accurate from what I can tell and I think it's clearer). Can remove if you prefer how it was.

Also adds some debug info in Advanced settings tab.

Not tested in MP4.