### PR TITLE
Add PBFallbackSession comparison type/option

### DIFF
--- a/src/Map.as
+++ b/src/Map.as
@@ -84,6 +84,12 @@ namespace Map {
             if(sessionRecord !is null && sessionRecord.cps.Length > currentRecord.cps.Length) {
                 compareSpeed = sessionRecord.cps[currentRecord.cps.Length];
             }
+        } else if(compareType == CompareType::PBFallbackSession) {
+            if(pbRecord !is null && pbRecord.cps.Length > currentRecord.cps.Length) {
+                compareSpeed = pbRecord.cps[currentRecord.cps.Length];
+            } else if(sessionRecord !is null && sessionRecord.cps.Length > currentRecord.cps.Length) {
+                compareSpeed = sessionRecord.cps[currentRecord.cps.Length];
+            }
         }
         currentRecord.cps.InsertLast(speed);
         if(compareSpeed == -1) {

--- a/src/Settings.as
+++ b/src/Settings.as
@@ -1,6 +1,7 @@
 enum CompareType {
     PersonalBest,
     SessionBest,
+    PBFallbackSession,
 }
 
 [Setting name="What speed should be compared" category="General" description="Show comparison to your personal best or your session best. Session best resets when a new map loads."]


### PR DESCRIPTION
This simply add the option to use the PersonalBest and fallback to SessionBest if it is not available.
I chose to not add this to the PersonalBest option since it might be confusing when having a PB but no splits for that PB recorded in Speed-Splits.