### PR TITLE
Add support for unfinished runs

### DIFF
--- a/src/AdvSettings.as
+++ b/src/AdvSettings.as
@@ -13,14 +13,15 @@ namespace AdvSettings{
 
         UI::Separator();
 
-        if (Map::pbRecord is null || Map::mapId == "") {
-            UI::TextWrapped("MAP: " + Map::mapId);
+        UI::TextWrapped("Map UID: " + Map::mapId);
+
+        if (Map::mapId == "") {
             UI::TextWrapped("No map speeds loaded.");
             return;
         }
 
-        UI::TextWrapped("Map UID: " + Map::mapId);
         DrawSpeedRecDebug("Current Speeds", Map::currentRecord);
+        DrawSpeedRecDebug("Unfinished Speeds", Map::unfinishedRun);
         DrawSpeedRecDebug("Session Record", Map::sessionRecord);
         DrawSpeedRecDebug("PB Record", Map::pbRecord);
     }

--- a/src/Ghost.as
+++ b/src/Ghost.as
@@ -40,9 +40,42 @@ namespace Ghost {
         return pb;
     }
 
+#elif TURBO
+
+    uint GetLastRunTime() {
+        return 0;
+    }
+
+    int maxInt = 2147483647;
+    uint GetPB() {
+        // print("Getting map pb");
+        auto app = cast<CTrackMania>(GetApp());
+        auto playground = cast<CGameCtnPlayground@>(app.CurrentPlayground);
+        auto player = cast<CTrackManiaPlayer>(playground.GameTerminals[0].ControlledPlayer);
+        int time = maxInt;
+
+        if(app.PlaygroundScript !is null){
+            auto records = app.PlaygroundScript.DataMgr.Records;
+            // See https://github.com/Phlarx/tm-ultimate-medals/blob/76bf469aa3979c90b78a4ecb87c3a7423b635647/UltimateMedals.as#L581
+            for(uint i = 0; i < records.Length; i++) {
+                print("i=" + i + ", GhostName: " + records[i].GhostName + ", Time: " + records[i].Time);
+                // TODO: identify game mode, and then load arcade or dual-driver best instead? only loads for campaign maps right now
+                // if(records[i].GhostName == "Duo_BestGhost") {
+                if(records[i].GhostName == "Solo_BestGhost") {
+                        time = records[i].Time;
+                        break;
+                }
+                // this shouldn't loop more than a few times, since each entry is a different record type
+            }
+        }
+
+        print("LOWEST TIME FROM SCRIPT: " + tostring(time));
+        return time;
+    }
+
 #elif MP4
 
-	uint GetLastRunTime() {
+    uint GetLastRunTime() {
         return 0;
     }
 

--- a/src/Ghost.as
+++ b/src/Ghost.as
@@ -58,8 +58,8 @@ namespace Ghost {
             auto records = app.PlaygroundScript.DataMgr.Records;
             // See https://github.com/Phlarx/tm-ultimate-medals/blob/76bf469aa3979c90b78a4ecb87c3a7423b635647/UltimateMedals.as#L581
             for(uint i = 0; i < records.Length; i++) {
-                print("i=" + i + ", GhostName: " + records[i].GhostName + ", Time: " + records[i].Time);
                 // TODO: identify game mode, and then load arcade or dual-driver best instead? only loads for campaign maps right now
+                // print("i=" + i + ", GhostName: " + records[i].GhostName + ", Time: " + records[i].Time);
                 // if(records[i].GhostName == "Duo_BestGhost") {
                 if(records[i].GhostName == "Solo_BestGhost") {
                         time = records[i].Time;

--- a/src/Map.as
+++ b/src/Map.as
@@ -14,12 +14,11 @@ namespace Map {
     uint GetMapPB() {
         uint pb = 0;
 
-        if(IO::FileExists(FilePath)) {
+        @pbRecord = SpeedRecording::FromFile(FilePath);
+        if(pbRecord !is null) {
             // First try get PB from speedsplit file:
-            @pbRecord = SpeedRecording::FromFile(FilePath);
             pb = pbRecord.time;
         } else {
-            @pbRecord = null;
             // Otherwise try from pb ghost
             pb = Ghost::GetPB();
         }

--- a/src/Map.as
+++ b/src/Map.as
@@ -61,6 +61,7 @@ namespace Map {
         @sessionRecord = null;
         currentPB = GetMapPB();
         sessionPB = 0;
+        HandleRunStart();
         print("Map switched to " + mapId + ", pb = " + currentPB);
     }
 

--- a/src/Map.as
+++ b/src/Map.as
@@ -91,6 +91,7 @@ namespace Map {
                 compareSpeed = sessionRecord.cps[currentRecord.cps.Length];
             }
         }
+
         currentRecord.cps.InsertLast(speed);
         if(compareSpeed == -1) {
             GUI::hasDiff = false;
@@ -99,6 +100,12 @@ namespace Map {
             GUI::difference = speed - compareSpeed;
         }
         GUI::showTime = Time::Now;
+
+        // auto cps = "" + currentRecord.cps[0];
+        // for(uint i = 1; i < currentRecord.cps.Length; i++){
+        //     cps = cps + ", " + currentRecord.cps[i];
+        // }
+        // print("cps: " + cps);
     }
 
     void HandleFinish(uint time, bool isOnline) {

--- a/src/Map.as
+++ b/src/Map.as
@@ -112,6 +112,7 @@ namespace Map {
     }
 
     void HandleFinish(uint time, bool isOnline) {
+        if(mapId == "") return;
         currentRecord.time = time;
         currentRecord.isOnline = isOnline;
         auto isPB = time <= currentPB || currentPB == 0;

--- a/src/Map.as
+++ b/src/Map.as
@@ -45,7 +45,11 @@ namespace Map {
 
 #endif
 
+#if TMNEXT || MP4
         auto currentMapId = GetApp().RootMap.MapInfo.MapUid;
+#elif TURBO
+        auto currentMapId = GetApp().Challenge.MapInfo.MapUid;
+#endif
         if(mapId == currentMapId) return;
 
         // Map switch

--- a/src/Race.as
+++ b/src/Race.as
@@ -86,6 +86,7 @@ namespace Race {
 
 		auto playground = cast<CGamePlayground@>(GetApp().CurrentPlayground);
 		if(playground is null) return;
+		if(playground.GameTerminals.Length == 0) return;
 		auto terminal = playground.GameTerminals[0];
 		if(terminal is null) return;
 		auto player = cast<CTrackManiaPlayer@>(terminal.ControlledPlayer);
@@ -120,6 +121,7 @@ namespace Race {
 		auto app = cast<CTrackMania@>(GetApp());
 		auto playground = cast<CGamePlayground@>(app.CurrentPlayground);
 		if(playground is null) return;
+		if(playground.GameTerminals.Length == 0) return;
 		auto terminal = playground.GameTerminals[0];
 		if(terminal is null) return;
 		auto player = cast<CTrackManiaPlayer@>(terminal.ControlledPlayer);

--- a/src/Settings.as
+++ b/src/Settings.as
@@ -37,6 +37,9 @@ bool showSplitDecimal = false;
 [Setting name="Use world speed instead of front speed" category="General" description="World speed takes into account your sideways speed, it is more accurate when drifting or sliding sideways"]
 bool useWorldSpeed = true;
 
+[Setting name="Use unfinished runs" category="General" description="When there is no finished run (PB or Session) yet, use the furthest unfinished run"]
+bool useUnfinishedRuns = true;
+
 
 #if MP4
 

--- a/src/SpeedRecording.as
+++ b/src/SpeedRecording.as
@@ -1,6 +1,7 @@
 class SpeedRecording {
 
     float[]@ cps = {};
+    uint lastCpTime = 0; // Only used for unfinished runs
     uint time = 0;
     bool isOnline = false;
 
@@ -34,7 +35,7 @@ class SpeedRecording {
         for (uint i = 0; i < cps.Length; i++) {
             cpsStr.InsertLast(tostring(cps[i]));
         }
-        UI::TextWrapped("SpeedRecording < time = " + Time::Format(time) + ", cps = { " + (string::Join(cpsStr, " / ")) + " } >");
+        UI::TextWrapped("SpeedRecording < time = " + Time::Format(time) + ", cps = { " + (string::Join(cpsStr, " / ")) + " }" + ", lastCpTime = " + Time::Format(lastCpTime) + " >");
     }
 
 }

--- a/src/SpeedRecording.as
+++ b/src/SpeedRecording.as
@@ -53,6 +53,15 @@ namespace SpeedRecording {
             IO::Delete(path);
             return null;
         }
+#elif TURBO
+        auto playground = cast<CTrackManiaRaceNew>(GetApp().CurrentPlayground);
+        auto playgroundScript = cast<CTrackManiaRaceRules>(GetApp().PlaygroundScript);
+        print(playgroundScript.MapNbLaps);
+        if(version < 2 && playgroundScript.MapNbLaps > 1) { // ?? Needs >1 or >0 ??
+            print("Old splits version on MultiLap map found! Deleting splits for this map.");
+            IO::Delete(path);
+            return null;
+        }
 #endif
 
         if(version == 0) {

--- a/src/SpeedRecording.as
+++ b/src/SpeedRecording.as
@@ -8,8 +8,8 @@ class SpeedRecording {
         print("ToFile! time: " + time + ", " + path);
         Json::Value speeds = Json::Object();
 
-        // version: 1
-        speeds["version"] = 1;
+        // version: 2
+        speeds["version"] = 2;
         speeds["time"] = time;
         speeds["isOnline"] = isOnline;
 
@@ -47,10 +47,20 @@ namespace SpeedRecording {
         if(json.GetType() != Json::Type::Object) return null;
 
         int version = json["version"].GetType() == Json::Type::Number ? json["version"] : 0;
+#if MP4
+        if(version < 2 && GetApp().RootMap.TMObjective_NbLaps > 1) {
+            print("Old splits version on MultiLap map found! Deleting splits for this map.");
+            IO::Delete(path);
+            return null;
+        }
+#endif
+
         if(version == 0) {
             return Version0(json);
         } else if(version == 1) {
-            return Version1(json);
+            return Version1or2(json, 1);
+        } else if(version == 2) {
+            return Version1or2(json, 2);
         } else {
             warn("Unsupported recorded speeds json version: " + path);
         }
@@ -79,7 +89,7 @@ namespace SpeedRecording {
         return result;
     }
 
-    SpeedRecording@ Version1(Json::Value json) {
+    SpeedRecording@ Version1or2(Json::Value json, uint version) {
         auto result = SpeedRecording();
         result.time = json["time"];
         result.isOnline = json["isOnline"];
@@ -87,7 +97,7 @@ namespace SpeedRecording {
         for(uint i = 0; i < json['cps'].Length; i++) {
             result.cps.InsertLast(json['cps'][i]);
         }
-        print("V1: Loaded splits from file, online: " + result.isOnline + ", time: " + result.time + ", cp count: " + result.cps.Length);
+        print("V" + version + ": Loaded splits from file, online: " + result.isOnline + ", time: " + result.time + ", cp count: " + result.cps.Length);
         return result;
     }
 

--- a/src/SpeedRecording.as
+++ b/src/SpeedRecording.as
@@ -56,8 +56,7 @@ namespace SpeedRecording {
 #elif TURBO
         auto playground = cast<CTrackManiaRaceNew>(GetApp().CurrentPlayground);
         auto playgroundScript = cast<CTrackManiaRaceRules>(GetApp().PlaygroundScript);
-        print(playgroundScript.MapNbLaps);
-        if(version < 2 && playgroundScript.MapNbLaps > 1) { // ?? Needs >1 or >0 ??
+        if(version < 2 && playgroundScript.MapNbLaps > 1) {
             print("Old splits version on MultiLap map found! Deleting splits for this map.");
             IO::Delete(path);
             return null;

--- a/src/Waypoint.as
+++ b/src/Waypoint.as
@@ -42,6 +42,7 @@ namespace Waypoint {
 #elif TURBO
 
 		/* Detect checkpoints */
+		auto playground = GetApp().CurrentPlayground;
 		auto player = cast<CTrackManiaPlayer>(playground.GameTerminals[0].ControlledPlayer);
 		auto currentLap = player.CurrentNbLaps;
 		auto currentCP = player.CurLap.Checkpoints.Length;

--- a/src/Waypoint.as
+++ b/src/Waypoint.as
@@ -4,9 +4,11 @@
  */
 
 namespace Waypoint {
+#if TMNEXT
+	uint _preCPIdx = 0;
+#endif
 	uint _curLap = 0;
 	uint _curCP = 0;
-	uint _preCPIdx = 0;
 	
 	uint get_curCP() property { return _curCP; }
 	
@@ -16,10 +18,15 @@ namespace Waypoint {
 #if TMNEXT
 		auto playground = cast<CSmArenaClient>(GetApp().CurrentPlayground);
 		auto player = cast<CSmPlayer>(playground.GameTerminals[0].GUIPlayer);
-		
-		// Detect waypoints
 		MwFastBuffer<CGameScriptMapLandmark@> landmarks = playground.Arena.MapLandmarks;
-		if(_preCPIdx != player.CurrentLaunchedRespawnLandmarkIndex && landmarks.Length > player.CurrentLaunchedRespawnLandmarkIndex) {
+
+		if(player.CurrentLaunchedRespawnLandmarkIndex >= landmarks.Length) {
+			print("Impossible! Players landmark-index is greater than count of Landmarks. Skipping...");
+			return;
+		}
+
+		// Detect waypoints
+		if(_preCPIdx != player.CurrentLaunchedRespawnLandmarkIndex) {
 			_preCPIdx = player.CurrentLaunchedRespawnLandmarkIndex;
 			auto landmark = landmarks[_preCPIdx];
 			if (landmark.Waypoint is null) {

--- a/src/Waypoint.as
+++ b/src/Waypoint.as
@@ -4,6 +4,7 @@
  */
 
 namespace Waypoint {
+	uint _curLap = 0;
 	uint _curCP = 0;
 	uint _preCPIdx = 0;
 	
@@ -44,11 +45,16 @@ namespace Waypoint {
 
 		/* Detect checkpoints */
 		auto playground = cast<CTrackManiaRaceNew>(GetApp().CurrentPlayground);
-		auto scriptPlayer = cast<CTrackManiaPlayer>(playground.GameTerminals[0].GUIPlayer).ScriptAPI;
-		if(scriptPlayer.CurLap.Checkpoints.Length != _curCP && scriptPlayer.CurLap.Checkpoints.Length > 0) {
+		auto player = cast<CTrackManiaPlayer>(playground.GameTerminals[0].GUIPlayer);
+		uint currentLap = player.CurrentNbLaps;
+		uint currentCP = player.ScriptAPI.CurLap.Checkpoints.Length;
+
+		if(currentLap > _curLap || currentCP > _curCP) {
 			Map::HandleCheckpoint();
 		}
-		_curCP = scriptPlayer.CurLap.Checkpoints.Length;
+
+		_curLap = currentLap;
+		_curCP = currentCP;
 
 #endif
 

--- a/src/Waypoint.as
+++ b/src/Waypoint.as
@@ -36,10 +36,15 @@ namespace Waypoint {
 
 		/* Detect checkpoints */
 		auto player = cast<CTrackManiaPlayer>(playground.GameTerminals[0].ControlledPlayer);
-		if(player.CurLap.Checkpoints.Length != _curCP) {
+		auto currentLap = player.CurrentNbLaps;
+		auto currentCP = player.CurLap.Checkpoints.Length;
+
+		if(currentLap > _curLap || currentCP > _curCP) {
 			Map::HandleCheckpoint();
 		}
-		_curCP = player.CurLap.Checkpoints.Length;
+
+		_curLap = currentLap;
+		_curCP = currentCP;
 		
 #elif MP4
 


### PR DESCRIPTION
This adds support for using the splits from the furthest unfinished run if there isn't a finished one (PB or Session).

This PR currently builds on top of #22, that's why it contains so many changes. It should also work standalone (though I haven't tested that) and I can base this on current master if you want that for some reason. :)