### PR TITLE
Add MultiLap support for MP4 & Turbo

### DIFF
--- a/src/Ghost.as
+++ b/src/Ghost.as
@@ -40,6 +40,41 @@ namespace Ghost {
         return pb;
     }
 
+#elif TURBO
+
+    uint GetLastRunTime() {
+        return 0;
+    }
+
+    int maxInt = 2147483647;
+    uint GetPB() {
+        // print("Getting map pb");
+        auto app = cast<CTrackMania>(GetApp());
+        CGameCtnPlayground@ playground = cast<CGameCtnPlayground@>(app.CurrentPlayground);
+        auto terminal = playground.GameTerminals[0];
+        if(terminal is null) return maxInt;
+        auto player = cast<CTrackManiaPlayer>(terminal.ControlledPlayer);
+        int time = maxInt;
+
+        if(app.PlaygroundScript !is null) {
+            auto records = app.PlaygroundScript.DataMgr.Records;
+            // See https://github.com/Phlarx/tm-ultimate-medals/blob/76bf469aa3979c90b78a4ecb87c3a7423b635647/UltimateMedals.as#L581
+            for(uint i = 0; i < records.Length; i++) {
+                // print("i=" + i + ", GhostName: " + records[i].GhostName + ", Time: " + records[i].Time);
+                // TODO: identify game mode, and then load arcade or dual-driver best instead? only loads for campaign maps right now
+                // if(records[i].GhostName == "Duo_BestGhost") {
+                if(records[i].GhostName == "Solo_BestGhost") {
+                        time = records[i].Time;
+                        break;
+                }
+                // this shouldn't loop more than a few times, since each entry is a different record type
+            }
+        }
+
+        print("LOWEST TIME FROM SCRIPT: " + tostring(time));
+        return time;
+    }
+
 #elif MP4
 
 	uint GetLastRunTime() {

--- a/src/Map.as
+++ b/src/Map.as
@@ -14,7 +14,7 @@ namespace Map {
     uint GetMapPB() {
         uint pb = 0;
 
-        if(IO::FileExists(FilePath)) {
+        if(mapId != "" && IO::FileExists(FilePath)) {
             // First try get PB from speedsplit file:
             @pbRecord = SpeedRecording::FromFile(FilePath);
             pb = pbRecord.time;
@@ -106,6 +106,7 @@ namespace Map {
     }
 
     void HandleFinish(uint time, bool isOnline) {
+        if(mapId == "") return;
         currentRecord.time = time;
         currentRecord.isOnline = isOnline;
         auto isPB = time <= currentPB || currentPB == 0;

--- a/src/Map.as
+++ b/src/Map.as
@@ -46,7 +46,11 @@ namespace Map {
 
 #endif
 
+#if TMNEXT || MP4
         auto currentMapId = GetApp().RootMap.MapInfo.MapUid;
+#elif TURBO
+        auto currentMapId = GetApp().Challenge.MapInfo.MapUid;
+#endif
         if(mapId == currentMapId) return;
 
         // Map switch

--- a/src/Race.as
+++ b/src/Race.as
@@ -86,6 +86,7 @@ namespace Race {
 
 		auto playground = cast<CGamePlayground@>(GetApp().CurrentPlayground);
 		if(playground is null) return;
+		if(playground.GameTerminals.Length == 0) return;
 		auto terminal = playground.GameTerminals[0];
 		if(terminal is null) return;
 		auto player = cast<CTrackManiaPlayer@>(terminal.ControlledPlayer);
@@ -120,6 +121,7 @@ namespace Race {
 		auto app = cast<CTrackMania@>(GetApp());
 		auto playground = cast<CGamePlayground@>(app.CurrentPlayground);
 		if(playground is null) return;
+		if(playground.GameTerminals.Length == 0) return;
 		auto terminal = playground.GameTerminals[0];
 		if(terminal is null) return;
 		auto player = cast<CTrackManiaPlayer@>(terminal.ControlledPlayer);

--- a/src/Race.as
+++ b/src/Race.as
@@ -81,6 +81,39 @@ namespace Race {
 		if (sequence != CGamePlaygroundUIConfig::EUISequence::Finish)
 			finishHandled = false;
 
+#elif TURBO
+		// Check for run start
+
+		auto playground = cast<CGamePlayground@>(GetApp().CurrentPlayground);
+		if(playground is null) return;
+		auto terminal = playground.GameTerminals[0];
+		if(terminal is null) return;
+		auto player = cast<CTrackManiaPlayer@>(terminal.ControlledPlayer);
+
+		auto raceState = player.RaceState;
+		if(raceState == CTrackManiaPlayer::ERaceState::Running && !retireHandled) {
+			print("Start!");
+			Map::HandleRunStart();
+			retireHandled = true;
+		} else if(retireHandled && raceState != CTrackManiaPlayer::ERaceState::Running) {
+			retireHandled = false;
+		}
+
+		// Check for run finish
+
+		auto prevRecord = playground.PrevReplayRecord;
+		if(prevRecord !is null && prevRecord.Ghosts.Length > 0) {
+			auto ghost = prevRecord.Ghosts[0];
+			if(player.RaceState == CTrackManiaPlayer::ERaceState::Finished
+				&& lastPrevRaceTime != player.Score.LastRaceTime) {
+				lastPrevRaceTime = player.Score.LastRaceTime;
+				if(lastPrevRaceTime < 3000000000) {
+					print("Finish!: " + lastPrevRaceTime);
+					Map::HandleFinish(lastPrevRaceTime, false);
+				}
+			}
+		}
+
 #elif MP4
 		// Check for run start
 

--- a/src/Waypoint.as
+++ b/src/Waypoint.as
@@ -4,6 +4,7 @@
  */
 
 namespace Waypoint {
+	uint _curLap = 0;
 	uint _curCP = 0;
 	uint _preCPIdx = 0;
 	
@@ -35,21 +36,39 @@ namespace Waypoint {
 
 		/* Detect checkpoints */
 		auto playground = GetApp().CurrentPlayground;
+		if(playground.GameTerminals.Length == 0) return;
 		auto player = cast<CTrackManiaPlayer>(playground.GameTerminals[0].ControlledPlayer);
-		if(player.CurLap.Checkpoints.Length != _curCP) {
+		uint currentLap = player.CurrentNbLaps;
+		uint currentCP = player.CurLap.Checkpoints.Length;
+
+		// if(currentLap != _curLap || currentCP != _curCP) {
+		// 	print("lap: " + currentLap + ", cp: " + currentCP);
+		// }
+		if(currentLap > _curLap || currentCP > _curCP) {
 			Map::HandleCheckpoint();
 		}
-		_curCP = player.CurLap.Checkpoints.Length;
+
+		_curLap = currentLap;
+		_curCP = currentCP;
 		
 #elif MP4
 
 		/* Detect checkpoints */
 		auto playground = cast<CTrackManiaRaceNew>(GetApp().CurrentPlayground);
-		auto scriptPlayer = cast<CTrackManiaPlayer>(playground.GameTerminals[0].GUIPlayer).ScriptAPI;
-		if(scriptPlayer.CurLap.Checkpoints.Length != _curCP && scriptPlayer.CurLap.Checkpoints.Length > 0) {
+		if(playground.GameTerminals.Length == 0) return;
+		auto player = cast<CTrackManiaPlayer>(playground.GameTerminals[0].GUIPlayer);
+		uint currentLap = player.CurrentNbLaps;
+		uint currentCP = player.ScriptAPI.CurLap.Checkpoints.Length;
+
+		// if(currentLap != _curLap || currentCP != _curCP) {
+		// 	print("lap: " + currentLap + ", cp: " + currentCP);
+		// }
+		if(currentLap > _curLap || currentCP > _curCP) {
 			Map::HandleCheckpoint();
 		}
-		_curCP = scriptPlayer.CurLap.Checkpoints.Length;
+
+		_curLap = currentLap;
+		_curCP = currentCP;
 
 #endif
 

--- a/src/Waypoint.as
+++ b/src/Waypoint.as
@@ -34,6 +34,7 @@ namespace Waypoint {
 #elif TURBO
 
 		/* Detect checkpoints */
+		auto playground = GetApp().CurrentPlayground;
 		auto player = cast<CTrackManiaPlayer>(playground.GameTerminals[0].ControlledPlayer);
 		if(player.CurLap.Checkpoints.Length != _curCP) {
 			Map::HandleCheckpoint();


### PR DESCRIPTION
**Changes:**
- TmTurbo: add MultiLap support
- MP4: add MultiLap support
- All: Bump splits-file version to 2
  - TmNext: Nothing changes
  - TmTurbo & MP4: Indicates that the splits-file is correct for MultiLap maps

**Note:**
I have upgraded the splits-file version to 2. The only difference to v1 is the meaning in MP4 & Turbo contexts to indicate that it supports MultiLaps.
When you load a MultiLap map in MP4 & TmTurbo with an old (version < 2) splits-file it will be deleted! Reasoning is that it only contains splits for one lap is therefore useless.